### PR TITLE
[TES-5250] Mark tes-operator 1.3.0 and 1.5.0 as deprecated

### DIFF
--- a/charts/tes-operator/deprecated-versions.txt
+++ b/charts/tes-operator/deprecated-versions.txt
@@ -1,0 +1,35 @@
+# TES Operator - Deprecated and End-of-Life Chart Versions
+#
+# This file is the source of truth for TES operator chart lifecycle state.
+# It lives alongside index.yaml since it directly controls what gets applied here.
+#
+# During Step 5 of the release process, ensure the actions below are applied
+# before opening the PR:
+# Release process: https://tenable.atlassian.net/wiki/spaces/TES/pages/2387771622/Release+Process
+#
+# TODO: A script will be added in the future to automate both actions below,
+# removing the need for the manual Step 5 checks:
+#   - DEPRECATED: set `deprecated: true` in index.yaml for listed versions
+#   - EOL:        delete the version .tgz from releases/ and regenerate index.yaml
+#
+# TES Support Policy: https://tenable.atlassian.net/wiki/spaces/TES/pages/3468853255
+#   - 12-18 months from GA → deprecated (helm warning on install, still available)
+#   - 18+ months from GA  → EOL (removed from charts.tenable.com)
+#
+# Format: <chart-version> | <app-version> | <status> (deprecated|eol) | <status-since-date YYYY-MM-DD>
+
+# --- DEPRECATED (12-18 months) ---
+# During Step 5 (https://tenable.atlassian.net/wiki/spaces/TES/pages/2387771622/Release+Process#Step-5):
+# ensure these have `deprecated: true` in index.yaml
+1.5.0 | 1.5.0 | deprecated | 2026-05-31
+1.3.0 | 1.3.0 | deprecated | 2026-01-31
+
+# --- END OF LIFE (18+ months) ---
+# During Step 5 (https://tenable.atlassian.net/wiki/spaces/TES/pages/2387771622/Release+Process#Step-5):
+# ensure these .tgz files are removed from releases/ and index regenerated
+1.2.0 | 1.2.0 | eol | 2026-04-30
+1.0.4 | 1.0.4 | eol | 2026-02-28
+1.0.3 | 1.0.3 | eol | 2026-02-28
+1.0.2 | 1.0.2 | eol | 2026-02-28
+1.0.1 | 1.0.1 | eol | 2026-02-28
+1.0.0 | 1.0.0 | eol | 2026-02-28

--- a/index.yaml
+++ b/index.yaml
@@ -289,6 +289,7 @@ entries:
   - apiVersion: v2
     appVersion: 1.3.0
     created: "2026-06-17T14:07:12.990458443Z"
+    deprecated: true
     description: Tenable Enclave Security operator
     digest: 4e3b4a7cb25d76736f457769bd3eddc30d64503571e6b954a838712591760264
     name: tes-operator

--- a/index.yaml
+++ b/index.yaml
@@ -279,6 +279,7 @@ entries:
   - apiVersion: v2
     appVersion: 1.5.0
     created: "2026-06-17T14:07:12.990887731Z"
+    deprecated: true
     description: Tenable Enclave Security operator
     digest: fb8f7a7154249388af158ba18fbdd2c1eecacca19c841f3ae190817b036575ba
     name: tes-operator


### PR DESCRIPTION
## Summary
- Marks tes-operator chart versions 1.3.0 and 1.5.0 as deprecated in the helm repository index, per the TES 18-month version lifecycle policy.

## Changes
- `index.yaml`: Added `deprecated: true` to tes-operator 1.3.0 (GA 2025-01-13, deprecated since 2026-01-31)
- `index.yaml`: Added `deprecated: true` to tes-operator 1.5.0 (GA 2025-05-29, deprecated since 2026-05-31)

## Background
Both versions are in the 12-18 month deprecated window per the TES version lifecycle policy. Helm will print a deprecation warning on install but will not block existing customers from using these versions.

Policy: https://tenable.atlassian.net/wiki/spaces/TES/pages/3468853255
Ticket: TES-5250

## Breaking Changes
None — existing installations are unaffected.

## Test Plan
- [ ] Run `helm repo update tenable && helm search repo tenable/tes-operator --versions` and verify 1.3.0 and 1.5.0 show as deprecated